### PR TITLE
Remove CLA related things from contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,6 @@
 
 We are glad you are here! We think it's awesome that you want to spend time helping us make React Native Segmented Arc even better. We really value the community we get to be a part of, and we are grateful for your contribution.
 
-Contribution requires signing a Contributor License Agreement (CLA) via HelloSign, a process automated as a part of a pull request. Your Github email address must match the email address used to sign the CLA. Github has [documentation](https://help.github.com/articles/setting-your-commit-email-address-on-github/) on setting email addresses. Your git email must also match this email address.
-
 ## How to Contribute to React Native Segmented Arc
 
 The basic workflow:
@@ -18,20 +16,15 @@ The basic workflow:
      - `support/`: for general refactoring
      - `hotfix/`: something broke and we need to fix it now
 4. Submit a Pull Request! Do it early and mark it `WIP` so a maintainer knows it's not ready for review just yet.
-5. If you haven't signed our CLA before, then you will receive an email from HelloSign to sign the CLA.
-   - The CLA request will be sent to the email address associated with your Github account.
-   - You cannot have your PR merged without signing the PR.
-   - If you already submitted a PR and need to correct your user.name and/or user.email please do so and then use `git commit --amend --reset-author` and then `git push --force` to correct the PR.
-6. Request review from one of our maintainers.
-7. Get Approval. We'll let you know if there are any changes that are needed.
-8. Boom! You can merge your changes into React Native Segmented Arc.
+5. Request review from one of our maintainers.
+6. Get Approval. We'll let you know if there are any changes that are needed.
+7. Boom! You can merge your changes into React Native Segmented Arc.
 
 Pull Requests:
 
 - Submit a PR to get your changes approved.
 - Request review from a [maintainer](MAINTAINERS.md).
 - Make sure you include an explanation of what's changed, why, and anything these changes affect.
-- The CLA-bot will confirm that you're approved to contribute.
 - Our maintainer will review and approve your PR.
 - Merge!
 


### PR DESCRIPTION
Removed CLA and CLA bot verbiage from `CONTRIBUTING` as we have discussed in the project channel. 