### PR TITLE
Make useNativeDriver false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
           name: Publish package
-          command: npm publish --access public
+          command: npm publish
       - run:
           name: Create Git Version Tag
           command: "PACKAGE_VERSION=$(cat package.json | grep \\\"version\\\" | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]') && git tag v$PACKAGE_VERSION && git push --tags"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipt/segmented-arc-for-react-native",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "description": "Segmented arc component for React Native ",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
For some reason, the example project cannot animate if it's run on Android. Tested with @wdavis47 on his physical device too. I also tried installing the package on expo generated app. The same thing issue is happing there too.

We discovered that there is no significant difference between enabling and disabling the `useNativeDriver`. It's likely related to the fact that we are not animating any react native views but just providing values from the animation to SVG. 

This was the last change we wanted to make before open-sourcing this package. So I changed config files too. 