### PR TITLE
Fix example app issues when installing local copy of the arc

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,8 @@
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint .",
-    "pod": "(rm -rf ios/Pods && cd ios/ && pod install --repo-update)"
+    "pod": "(rm -rf ios/Pods && cd ios/ && pod install --repo-update)",
+    "postinstall": "(cd node_modules/@shipt/segmented-arc-for-react-native && yarn install --production)"
   },
   "dependencies": {
     "@shipt/segmented-arc-for-react-native": "file:../",


### PR DESCRIPTION
When installing a package from a file, `yarn` seems to copy the entire folder, including any dev dependencies that might have been installed. This meant that if you built the example app after installing the dev dependencies for the arc, duplicate versions of `react` would run in the example app and cause it to crash.

To fix this issue, a new postinstall script will run that will prune any dev dependencies out of the example apps copy of the arc. 