### PR TITLE
support scaling the display scale of arc segments

### DIFF
--- a/src/__tests__/SegmentedArc.spec.js
+++ b/src/__tests__/SegmentedArc.spec.js
@@ -96,4 +96,62 @@ describe('SegmentedArc', () => {
     wrapper = getWrapper(props);
     expect(wrapper.getByTestId(testId).props).toMatchSnapshot();
   });
+
+  it('renders segments with arc degree scales', () => {
+    const segments = [
+      {
+        scale: 0.25,
+        arcDegreeScale: 0.5,
+        filledColor: '#FF0000',
+        emptyColor: '#F2F3F5',
+        data: { label: 'First Segment' }
+      },
+      {
+        scale: 0.02,
+        arcDegreeScale: 0.3,
+        filledColor: '#FFA500',
+        emptyColor: '#F2F3F5',
+        data: { label: 'Second Segment' }
+      },
+      {
+        scale: 0.02,
+        arcDegreeScale: 0.2,
+        filledColor: '#FFA500',
+        emptyColor: '#F2F3F5',
+        data: { label: 'Third Segment' }
+      }
+    ];
+    wrapper = getWrapper({ ...props, segments });
+    expect(wrapper.getByTestId(testId).props).toMatchSnapshot();
+    expect(Animated.timing).toHaveBeenCalledTimes(1);
+    expect(Easing.out).toHaveBeenCalledWith(Easing.ease);
+  });
+
+  it('renders with ensured arc degree scales when missing from segments', () => {
+    const segments = [
+      {
+        scale: 0.25,
+        arcDegreeScale: 0.5,
+        filledColor: '#FF0000',
+        emptyColor: '#F2F3F5',
+        data: { label: 'First Segment' }
+      },
+      {
+        scale: 0.02,
+        filledColor: '#FFA500',
+        emptyColor: '#F2F3F5',
+        data: { label: 'Second Segment' }
+      },
+      {
+        scale: 0.02,
+        filledColor: '#FFA500',
+        emptyColor: '#F2F3F5',
+        data: { label: 'Third Segment' }
+      }
+    ];
+    wrapper = getWrapper({ ...props, segments });
+    expect(wrapper.getByTestId(testId).props).toMatchSnapshot();
+    expect(Animated.timing).toHaveBeenCalledTimes(1);
+    expect(Easing.out).toHaveBeenCalledWith(Easing.ease);
+  });
 });

--- a/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
+++ b/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
@@ -384,6 +384,224 @@ Object {
 }
 `;
 
+exports[`SegmentedArc renders segments with arc degree scales 1`] = `
+Object {
+  "children": Array [
+    <Svg
+      height={126}
+      preserveAspectRatio="xMidYMid meet"
+      width={240}
+    >
+      <Context.Provider
+        value={
+          Object {
+            "animationDuration": 1000,
+            "arcAnimatedValue": 0,
+            "arcSegmentDegree": 58.666666666666664,
+            "arcsStart": 0,
+            "capInnerColor": "#28E037",
+            "capOuterColor": "#FFFFFF",
+            "center": 120,
+            "emptyArcWidth": 8,
+            "filledArcWidth": 8,
+            "isAnimated": true,
+            "lastFilledSegment": Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "Third Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 180,
+              "filled": 180,
+              "filledColor": "#FFA500",
+              "isComplete": true,
+              "start": 144.8,
+            },
+            "margin": 12,
+            "radius": 100,
+            "ranges": Array [],
+            "rangesTextColor": "#000000",
+            "rangesTextStyle": Object {
+              "fontSize": 12,
+            },
+            "spaceBetweenSegments": 2,
+            "totalArcs": 3,
+          }
+        }
+      >
+        <Segment
+          arc={
+            Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "First Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 88,
+              "filled": 88,
+              "filledColor": "#FF0000",
+              "isComplete": true,
+              "start": 0,
+            }
+          }
+        />
+        <Segment
+          arc={
+            Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "Second Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 142.8,
+              "filled": 142.8,
+              "filledColor": "#FFA500",
+              "isComplete": true,
+              "start": 90,
+            }
+          }
+        />
+        <Segment
+          arc={
+            Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "Third Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 180,
+              "filled": 180,
+              "filledColor": "#FFA500",
+              "isComplete": true,
+              "start": 144.8,
+            }
+          }
+        />
+        <Cap />
+      </Context.Provider>
+    </Svg>,
+    undefined,
+  ],
+  "style": Object {
+    "alignItems": "center",
+  },
+  "testID": "container",
+}
+`;
+
+exports[`SegmentedArc renders with ensured arc degree scales when missing from segments 1`] = `
+Object {
+  "children": Array [
+    <Svg
+      height={126}
+      preserveAspectRatio="xMidYMid meet"
+      width={240}
+    >
+      <Context.Provider
+        value={
+          Object {
+            "animationDuration": 1000,
+            "arcAnimatedValue": 0,
+            "arcSegmentDegree": 58.666666666666664,
+            "arcsStart": 0,
+            "capInnerColor": "#28E037",
+            "capOuterColor": "#FFFFFF",
+            "center": 120,
+            "emptyArcWidth": 8,
+            "filledArcWidth": 8,
+            "isAnimated": true,
+            "lastFilledSegment": Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "Third Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 180,
+              "filled": 180,
+              "filledColor": "#FFA500",
+              "isComplete": true,
+              "start": 136,
+            },
+            "margin": 12,
+            "radius": 100,
+            "ranges": Array [],
+            "rangesTextColor": "#000000",
+            "rangesTextStyle": Object {
+              "fontSize": 12,
+            },
+            "spaceBetweenSegments": 2,
+            "totalArcs": 3,
+          }
+        }
+      >
+        <Segment
+          arc={
+            Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "First Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 88,
+              "filled": 88,
+              "filledColor": "#FF0000",
+              "isComplete": true,
+              "start": 0,
+            }
+          }
+        />
+        <Segment
+          arc={
+            Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "Second Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 134,
+              "filled": 134,
+              "filledColor": "#FFA500",
+              "isComplete": true,
+              "start": 90,
+            }
+          }
+        />
+        <Segment
+          arc={
+            Object {
+              "centerX": 120,
+              "centerY": 120,
+              "data": Object {
+                "label": "Third Segment",
+              },
+              "emptyColor": "#F2F3F5",
+              "end": 180,
+              "filled": 180,
+              "filledColor": "#FFA500",
+              "isComplete": true,
+              "start": 136,
+            }
+          }
+        />
+        <Cap />
+      </Context.Provider>
+    </Svg>,
+    undefined,
+  ],
+  "style": Object {
+    "alignItems": "center",
+  },
+  "testID": "container",
+}
+`;
+
 exports[`SegmentedArc renders with middle content 1`] = `
 Object {
   "children": Array [


### PR DESCRIPTION
Requirements:
1. keep existing implementations intact
2. support a segment value to adjust the size of the arc segments

Before/After screenies include the below segments:

```js

  const _segments = [
    {
      scale: 0.94,
      arcDegreeScale: 0.5,
      filledColor: firstSegmentFilledColor,
      emptyColor: firstSegmentEmptyColor,
      data: { label: firstSegmentLabel }
    },
    {
      scale: 0.02,
      arcDegreeScale: 0.3,
      filledColor: secondSegmentFilledColor,
      emptyColor: secondSegmentEmptyColor,
      data: { label: secondSegmentLabel }
    },
    {
      scale: 0.02,
      arcDegreeScale: 0.1,
      filledColor: thirdSegmentFilledColor,
      emptyColor: thirdSegmentEmptyColor,
      data: { label: thirdSegmentLabel }
    },
    {
      scale: 0.02,
      arcDegreeScale: 0.1,
      filledColor: fourthSegmentFilledColor,
      emptyColor: fourthSegmentEmptyColor,
      data: { label: fourthSegmentLabel }
    }
  ];
```

|Before|After|
|---|---|
|<img width="263" alt="image" src="https://github.com/shipt/segmented-arc-for-react-native/assets/24547965/dce03294-baab-4d53-a650-0298916cd64c">|<img width="290" alt="image" src="https://github.com/shipt/segmented-arc-for-react-native/assets/24547965/65010feb-b45f-4aa0-866c-7059c4f9330f">|