### PR TITLE
Update Circle CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - '38:6a:fc:cf:d5:bc:47:8f:a3:d2:70:21:95:ab:cf:f4'
+            - 'SHA256:qOCt49Q9PD/ktHiVTmpyPL9NgpRhtLU+stAxjmScZ2U'
       - <<: *yarn_install
       - run:
           name: Authenticate with registry

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1673,7 +1673,7 @@
     nullthrows "^1.1.1"
 
 "@shipt/segmented-arc-for-react-native@file:..":
-  version "1.1.0"
+  version "1.1.1"
   dependencies:
     prop-types "^15.8.1"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipt/segmented-arc-for-react-native",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Segmented arc component for React Native ",
   "main": "src/index.js",


### PR DESCRIPTION
Updated the CIrcleCI config to allow automatic tag generation when creating a new release. Last time it had [failed](https://app.circleci.com/pipelines/github/shipt/segmented-arc-for-react-native/236/workflows/92f452fa-d860-4abd-af35-7ed52324af73/jobs/244?invite=true#step-106-0_46) for not having right access. 