### PR TITLE
Feature: Scaled Segment Width

### DIFF
--- a/src/SegmentedArc.js
+++ b/src/SegmentedArc.js
@@ -12,6 +12,7 @@ const SegmentedArcContext = createContext();
 export const SegmentedArc = ({
   fillValue = 0,
   segments = [],
+  scaled = false,
   filledArcWidth = 8,
   emptyArcWidth = 8,
   spaceBetweenSegments = 2,
@@ -87,11 +88,11 @@ export const SegmentedArc = ({
   let remainingValue = fillValue;
 
   _ensureDefaultSegmentScale();
-  _ensureDefaultArcScale();
+  if (scaled) _ensureDefaultArcScale();
 
   let arcs = [];
   segments.forEach((segment, index) => {
-    const arcDegreeScale = segment.arcDegreeScale;
+    const arcDegreeScale = scaled ? segment.scale : segment.arcDegreeScale;
     const previousSegmentEnd = !!index ? arcs[index - 1].end : arcsStart;
     const start = previousSegmentEnd + (!!index ? spaceBetweenSegments : 0);
     const end = (arcDegree - totalSpacing) * arcDegreeScale + start;

--- a/src/SegmentedArc.js
+++ b/src/SegmentedArc.js
@@ -88,7 +88,7 @@ export const SegmentedArc = ({
   let remainingValue = fillValue;
 
   _ensureDefaultSegmentScale();
-  if (scaled) _ensureDefaultArcScale();
+  if (!scaled) _ensureDefaultArcScale();
 
   let arcs = [];
   segments.forEach((segment, index) => {


### PR DESCRIPTION
Allow for the segment width to be scaled alongside the specified segment scales

Here's an example of this in action:
![image](https://github.com/shipt/segmented-arc-for-react-native/assets/79180508/095105a7-ef62-4aa6-a70a-06aaf4871b42)
![scaled](https://github.com/shipt/segmented-arc-for-react-native/assets/79180508/06b71960-4505-4f7d-995a-d75c38a17b2e)
