### PR TITLE
Remove .isRequired from emptyColor prop

### DIFF
--- a/src/SegmentedArc.js
+++ b/src/SegmentedArc.js
@@ -7,6 +7,7 @@ import Segment from './components/Segment';
 import Cap from './components/Cap';
 import RangesDisplay from './components/RangesDisplay';
 
+
 const SegmentedArcContext = createContext();
 
 export const SegmentedArc = ({
@@ -28,7 +29,8 @@ export const SegmentedArc = ({
   capInnerColor = '#28E037',
   capOuterColor = '#FFFFFF',
   alignRangesWithSegments = true,
-  children
+  children,
+  emptyColor = '#F3F3F4'
 }) => {
   const [arcAnimatedValue] = useState(new Animated.Value(0));
   const animationRunning = useRef(false);
@@ -167,7 +169,8 @@ export const SegmentedArc = ({
             rangesTextStyle,
             capInnerColor,
             capOuterColor,
-            alignRangesWithSegments
+            alignRangesWithSegments,
+            emptyColor
           }}
         >
           {arcs.map((arc, index) => (
@@ -200,7 +203,7 @@ SegmentedArc.propTypes = {
     PropTypes.shape({
       scale: PropTypes.number,
       filledColor: PropTypes.string.isRequired,
-      emptyColor: PropTypes.string.isRequired,
+      emptyColor: PropTypes.string,
       data: PropTypes.object,
       arcDegreeScale: PropTypes.number
     })

--- a/src/SegmentedArc.js
+++ b/src/SegmentedArc.js
@@ -7,7 +7,6 @@ import Segment from './components/Segment';
 import Cap from './components/Cap';
 import RangesDisplay from './components/RangesDisplay';
 
-
 const SegmentedArcContext = createContext();
 
 export const SegmentedArc = ({
@@ -29,8 +28,7 @@ export const SegmentedArc = ({
   capInnerColor = '#28E037',
   capOuterColor = '#FFFFFF',
   alignRangesWithSegments = true,
-  children,
-  emptyColor = '#F3F3F4'
+  children
 }) => {
   const [arcAnimatedValue] = useState(new Animated.Value(0));
   const animationRunning = useRef(false);
@@ -169,8 +167,7 @@ export const SegmentedArc = ({
             rangesTextStyle,
             capInnerColor,
             capOuterColor,
-            alignRangesWithSegments,
-            emptyColor
+            alignRangesWithSegments
           }}
         >
           {arcs.map((arc, index) => (

--- a/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
+++ b/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
@@ -74,6 +74,7 @@ exports[`SegmentedArc automatically increases the component's height when arcDeg
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -255,6 +256,7 @@ exports[`SegmentedArc renders arc with ranges: shows ranges 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -442,6 +444,7 @@ exports[`SegmentedArc renders default 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -610,6 +613,7 @@ exports[`SegmentedArc renders segments with arc degree scales 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -761,6 +765,7 @@ exports[`SegmentedArc renders with ensured arc degree scales when missing from s
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -925,6 +930,7 @@ exports[`SegmentedArc renders with middle content 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -1120,6 +1126,7 @@ exports[`SegmentedArc sets the last segment for lastFilledSegment prop when fill
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
+            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {

--- a/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
+++ b/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
@@ -74,7 +74,6 @@ exports[`SegmentedArc automatically increases the component's height when arcDeg
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -256,7 +255,6 @@ exports[`SegmentedArc renders arc with ranges: shows ranges 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -444,7 +442,6 @@ exports[`SegmentedArc renders default 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -613,7 +610,6 @@ exports[`SegmentedArc renders segments with arc degree scales 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -765,7 +761,6 @@ exports[`SegmentedArc renders with ensured arc degree scales when missing from s
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -930,7 +925,6 @@ exports[`SegmentedArc renders with middle content 1`] = `
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {
@@ -1126,7 +1120,6 @@ exports[`SegmentedArc sets the last segment for lastFilledSegment prop when fill
             "capOuterColor": "#FFFFFF",
             "center": 120,
             "emptyArcWidth": 8,
-            "emptyColor": "#F3F3F4",
             "filledArcWidth": 8,
             "isAnimated": true,
             "lastFilledSegment": {


### PR DESCRIPTION
[CU-86b1fecet](https://shipt.clickup.com/t/86b1fecet)

The other day while testing Stats I saw a warning on the `Ratings` detail screen related to `emptyColor` on `SegmentedArc`. To address, I would like to propose removing `.isRequired` from the `propTypes` since `emptyColor` is not being used or required in `feedback-summary-component.js` in Neutron -- there the circle on `Ratings` detail screen will always show 100% (no `emptyColor` portion for the circle).

Warning:
<img src="https://github.com/user-attachments/assets/2aefa145-98d0-4be0-ab7b-ba62197e02ee" width=200> <img src="https://github.com/user-attachments/assets/e18993b1-6e77-438a-bcc0-705f8e657511" width=200>


When I mocked the removal on Neutron -- the removal of `.isRequired` on propTypes did resolve the issue of the warning for `emptyColor` on segments.

After:
<img src="https://github.com/user-attachments/assets/09080a35-ebc0-45a1-96be-e0324956290b" width=200>

If there are other suggestions for how to resolve this issue on Neutron rather than on this repository, please let me know and I can redirect my attention there.

~~_*Here I am also proposing adding a default definition for `emptyColor` as `#F3F3F4` to match `grey_100` on Neutron._~~ removed default color suggestion after conversation with Kyle and Tanner's comment, made a great point that this repository is being used by more than just Neutron. Point to consider in the future is a default color (such as transparent, per Tanner).
