### PR TITLE
fix(arcDegree) - Convert offsetAngle to radians to increase height correctly 

### DIFF
--- a/src/SegmentedArc.js
+++ b/src/SegmentedArc.js
@@ -64,7 +64,7 @@ export const SegmentedArc = ({
 
   if (arcDegree > 180) {
     const offsetAngle = (arcDegree - 180) / 2;
-    const heightOffset = effectiveRadius * Math.sin(offsetAngle);
+    const heightOffset = effectiveRadius * Math.sin(offsetAngle * (Math.PI / 180));
     svgHeight += heightOffset + 2 * margin + filledArcWidth;
   }
 

--- a/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
+++ b/src/__tests__/__snapshots__/SegmentedArc.spec.js.snap
@@ -4,7 +4,7 @@ exports[`SegmentedArc automatically increases the component's height when arcDeg
 {
   "children": [
     <Svg
-      height={249.8975806496848}
+      height={234.36753236814712}
       preserveAspectRatio="xMidYMid meet"
       width={240}
     >


### PR DESCRIPTION
The funcion `Math.sin` input is in radians, but the `heightOffset` was being calculated with degrees, which generated incorrect height values for some degrees (it coincided with correct heights at specific degrees, like `arcDegree=360`).

This PR sole change is to convert degrees into radians.

before (arcDegree=240º)
![before-240](https://github.com/user-attachments/assets/289df516-f49f-4733-95c9-d62fc2671448)

after (arcDegree=240º)
![after-240](https://github.com/user-attachments/assets/b4a4c41c-f932-4659-b19b-1585bea81571)

before (arcDegree=300º)
![before-300](https://github.com/user-attachments/assets/a69c58c8-d223-4187-8c4a-cc8461ec71c8)

after (arcDegree=300º)
![after-300](https://github.com/user-attachments/assets/0c3fcc2e-fe7e-4727-9d8c-f102d4aca1d6)
