### PR TITLE
Make animation start match the arc start

### DIFF
--- a/src/SegmentedArc.js
+++ b/src/SegmentedArc.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, createContext, useMemo } from 'react';
+import React, { useEffect, useRef, createContext, useMemo } from 'react';
 import { Animated, Easing, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
@@ -50,8 +50,9 @@ export const SegmentedArc = ({
     return null;
   }
 
-  const [arcAnimatedValue] = useState(new Animated.Value(0));
+  const arcAnimatedValue = useRef(new Animated.Value(0)).current;
   const currentAnimation = useRef(null);
+  const isInitialRender = useRef(true);
   useShowSegmentedArcWarnings({ segments: segmentsProps });
 
   const {
@@ -158,6 +159,11 @@ export const SegmentedArc = ({
       currentAnimation.current.stop();
     }
 
+    if (isInitialRender.current) {
+      arcAnimatedValue.setValue(arcsStart);
+      isInitialRender.current = false;
+    }
+
     const animation = Animated.timing(arcAnimatedValue, {
       toValue: lastFilledSegment.filled,
       duration: animationDuration,
@@ -182,7 +188,7 @@ export const SegmentedArc = ({
         currentAnimation.current = null;
       }
     };
-  }, [lastFilledSegment.filled, animationDuration, animationDelay, isAnimated]);
+  }, [lastFilledSegment.filled, animationDuration, animationDelay, isAnimated, arcsStart]);
 
   if (arcs.length === 0) {
     return null;

--- a/src/__tests__/SegmentedArc.spec.js
+++ b/src/__tests__/SegmentedArc.spec.js
@@ -371,6 +371,47 @@ describe('SegmentedArc', () => {
     expect(newMockStop).toHaveBeenCalled();
   });
 
+  it('initializes animation from arcsStart when arcCenterAngle is provided', () => {
+    const setValueSpy = jest.spyOn(Animated.Value.prototype, 'setValue');
+    Animated.timing.mockReturnValue(createCompletedAnimationMock());
+
+    const arcCenterAngle = 270;
+    const arcDegree = 360;
+    const expectedArcsStart = arcCenterAngle - arcDegree / 2; // 90
+
+    wrapper = getWrapper({ ...props, arcCenterAngle, arcDegree });
+
+    expect(setValueSpy).toHaveBeenCalledWith(expectedArcsStart);
+    expect(Animated.timing).toHaveBeenCalledTimes(1);
+
+    setValueSpy.mockRestore();
+  });
+
+  it('does not reset animation to arcsStart when fillValue changes dynamically', () => {
+    const setValueSpy = jest.spyOn(Animated.Value.prototype, 'setValue');
+    Animated.timing.mockReturnValue(createCompletedAnimationMock());
+
+    const arcCenterAngle = 270;
+    const arcDegree = 360;
+    const expectedArcsStart = arcCenterAngle - arcDegree / 2; // 90
+
+    wrapper = render(<SegmentedArc {...props} fillValue={25} arcCenterAngle={arcCenterAngle} arcDegree={arcDegree} />);
+
+    // setValue should have been called with arcsStart on initial render
+    expect(setValueSpy).toHaveBeenCalledWith(expectedArcsStart);
+    setValueSpy.mockClear();
+
+    Animated.timing.mockClear();
+    Animated.timing.mockReturnValue(createCompletedAnimationMock());
+
+    wrapper.rerender(<SegmentedArc {...props} fillValue={75} arcCenterAngle={arcCenterAngle} arcDegree={arcDegree} />);
+
+    // setValue should NOT be called with arcsStart on rerender
+    expect(setValueSpy).not.toHaveBeenCalledWith(expectedArcsStart);
+
+    setValueSpy.mockRestore();
+  });
+
   it('sets the last segment for lastFilledSegment prop when fillValue is equal or greater than 100%', () => {
     props.fillValue = 100;
     wrapper = getWrapper(props);


### PR DESCRIPTION
While testing, I noticed that the animation starts from 180 degrees, and I made sure it matches the arcStart. The dynamic animation is kept unchanged. 

Pay attention to the beginning of the video to see the bug. The cap goes from 180 to 90 degrees

## Before


https://github.com/user-attachments/assets/3e7dddd8-1025-4a6c-96e5-4bcaa23a9037

## After 


https://github.com/user-attachments/assets/7df79f37-47a1-43dd-8d3b-2748da6eb716

