### PR TITLE
ignore yarn

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ jsconfig.json
 
 # node.js
 #
-node_modules/
 npm-debug.log
 yarn-debug.log
 yarn-error.log
@@ -35,11 +34,9 @@ src/**/__tests__/
 .nvmrc
 .yarn/
 .yarnrc.yml
-babel.config.cjs
 
 # Docs
 CONTRIBUTING.md
-CHANGELOG.md
 
 # Example
 example/

--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,46 @@
+# OS
+.DS_Store
+
 # VSCode
 .vscode/
 jsconfig.json
 
 # node.js
 #
+node_modules/
 npm-debug.log
 yarn-debug.log
 yarn-error.log
+yarn.lock
 
 # Jest
 coverage/
 src/**/__tests__/
+**/__snapshots__/
 
+# CI/CD
+.circleci/
+.github/
+
+# Git
+.gitignore
+.gitattributes
+.husky/
+
+# Linting/Formatting
+.eslintrc
+.prettierrc
+
+# Tooling configs
+.nvmrc
+.yarn/
+.yarnrc.yml
+babel.config.cjs
+
+# Docs
+CONTRIBUTING.md
+CHANGELOG.md
+
+# Example
 example/
 example.gif


### PR DESCRIPTION
When we updated yarn, we forgot to include the yarn cache in `.npmignore`. This removes and cuts the package size significantly (50000x) 